### PR TITLE
New Vocabulary: colourful

### DIFF
--- a/_data/dictionary/c.yml
+++ b/_data/dictionary/c.yml
@@ -93,6 +93,12 @@
   custom: true
   notes: Noun form of the Norlunda verb _samnan_, meaning "to collect".
 
+- def: colourful
+  type: adjective
+  word: fara
+  origin: "*farwaz"
+  originDef: colourful
+  
 - def: comb
   type: noun
   word: kam


### PR DESCRIPTION
I have added the descendant of *farwaz (adjective) in lieu of  the noun, for now. Following the usual roots among Germanics, the word for 'colour' comes from *farwō, which is a suffixed form of *farwaz. 